### PR TITLE
Documentation with examples.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,24 @@
+# thyme
+
 [![Status](https://travis-ci.org/liyang/thyme.png)](https://travis-ci.org/liyang/thyme)
+
 <http://hackage.haskell.org/package/thyme>
+
+A Haskell date and time library based on [time](http://hackage.haskell.org/package/time).
+
+* Trades more speed for less precision.
+* Improves type-system constraints on date time arithmetic.
+
+## Building
+
+### Library
+
+```
+stack build --flag thyme:lens
+```
+
+### Haddock
+
+```
+stack haddock --flag thyme:lens
+```

--- a/src/Data/Thyme.hs
+++ b/src/Data/Thyme.hs
@@ -11,13 +11,20 @@ lifted 'Integer', as is done in "Data.Time".
 
 The tradeoffs for this design can be generalized as:
 
-    * Data.Thyme.Clock.'Data.Thyme.Clock.DiffTime' has a precision of /1 microsecond/,
-      and Data.Time.Clock.'Data.Time.Clock.DiffTime' has a precision of /1 picosecond/.
+    * Data.Time.Clock.'Data.Time.Clock.DiffTime' has a precision
+      of /1 picosecond/.
 
-    * Data.Thyme.Clock.'Data.Thyme.Clock.UTCTime' has a range of about a half million years
-      (from /-290419-11-07 19:59:05.224192 UTC/
-      to /294135-11-26 04:00:54.775807 UTC/), and Data.Time.Clock.'Data.Time.Clock.UTCTime' has
-      unbounded range.
+        - Data.Thyme.Clock.'Data.Thyme.Clock.DiffTime' has a precision
+          of /1 microsecond/.
+
+    * Data.Time.Clock.'Data.Time.Clock.UTCTime' has unbounded range.
+
+        - Data.Thyme.Clock.'Data.Thyme.Clock.UTCTime' has a range of about a
+          half million years, from /-290419-11-07 19:59:05.224192 UTC/
+          to /294135-11-26 04:00:54.775807 UTC/. It is therefore not
+          Y294K-compliant.
+
+
 
 "Data.Thyme" uses strict and unpacked tuples throughout, e.g. 'YearMonthDay' or
 'Data.Thyme.Calendar.WeekDate.WeekDate'. Descriptive 'Int' synonyms such

--- a/src/Data/Thyme.hs
+++ b/src/Data/Thyme.hs
@@ -1,27 +1,110 @@
--- | Thyme is a rewrite of the fine @time@ library, with a particular focus
--- on performance for applications that make heavy use of timestamps. For
--- example, 'UTCTime' is represented with μs precision as an
--- 'Data.Int.Int64', which gives a usable range from @-290419-11-07
--- 19:59:05.224192 UTC@ to @294135-11-26 04:00:54.775807 UTC@ in the future.
---
--- Conversions are provided as @Iso'@s from the
--- <http://hackage.haskell.org/package/lens lens> package, while
--- 'Data.AdditiveGroup.AdditiveGroup', 'Data.VectorSpace.VectorSpace' and
--- 'Data.AffineSpace.AffineSpace' from
--- <http://hackage.haskell.org/package/vector-space vector-space> allow for
--- more principled operations instead of 'Num', 'Fractional' & al.
---
--- Thyme uses strict and unpacked tuples throughout, e.g. 'YearMonthDay' or
--- 'Data.Thyme.Calendar.WeekDate.WeekDate'. Descriptive 'Int' synonyms such
--- as 'Year' and 'DayOfMonth' are also provided.
---
--- On platforms where 'Int' is 64-bits wide, types with an 'Enum' instance
--- can be used as 'Data.IntMap.Key's for 'Data.IntMap.IntMap', preferably
--- via the @EnumMap@ wrapper provided by
--- <http://hackage.haskell.org/package/enummapset-th>. In any case the 'Ord'
--- instances are much faster, if you must use 'Data.Map.Map'.
---
--- "Data.Thyme.Time" is a drop-in compatibility module for existing code.
+{- | "Data.Thyme" is a speed-optimized rewrite (with a bit of extra type-safety)
+of the excellent "Data.Time" module in the @time@ library.
+
+= Design
+
+== Implementation
+
+The performance improvement of "Data.Thyme" comes chiefly from representing
+times internally as primitive unlifted 'Data.Int.Int64' instead of
+lifted 'Integer', as is done in "Data.Time".
+
+The tradeoffs for this design can be generalized as:
+
+    * Data.Thyme.Clock.'Data.Thyme.Clock.DiffTime' has a precision of /1 microsecond/,
+      and Data.Time.Clock.'Data.Time.Clock.DiffTime' has a precision of /1 picosecond/.
+
+    * Data.Thyme.Clock.'Data.Thyme.Clock.UTCTime' has a range of about a half million years
+      (from /-290419-11-07 19:59:05.224192 UTC/
+      to /294135-11-26 04:00:54.775807 UTC/), and Data.Time.Clock.'Data.Time.Clock.UTCTime' has
+      unbounded range.
+
+"Data.Thyme" uses strict and unpacked tuples throughout, e.g. 'YearMonthDay' or
+'Data.Thyme.Calendar.WeekDate.WeekDate'. Descriptive 'Int' synonyms such
+as 'Year' and 'DayOfMonth' are also provided.
+
+On platforms where 'Int' is 64-bits wide, types with an 'Enum' instance
+such as 'Day' can be used as 'Data.IntMap.Key's for 'Data.IntMap.IntMap', preferably
+via the @EnumMap@ wrapper provided by
+<http://hackage.haskell.org/package/enummapset-th>. In any case the 'Ord'
+instances are much faster, if you must use 'Data.Map.Map'.
+
+== API
+
+Conversions are provided as "Control.Lens.Iso"s from the
+<http://hackage.haskell.org/package/lens lens> package, while
+'Data.AdditiveGroup.AdditiveGroup', 'Data.VectorSpace.VectorSpace' and
+'Data.AffineSpace.AffineSpace' from
+<http://hackage.haskell.org/package/vector-space vector-space> allow for
+more principled operations instead of 'Num', 'Fractional' & al.
+
+"Data.Thyme.Time" is a drop-in replacement module compatible with
+"Data.Time".
+
+= Brief Tutorial By Example
+
+===== Let's start by getting the current UTC date and time from the local system clock.
+
+@
+import "Data.Thyme.Clock"
+
+__t₀__ <- 'Data.Thyme.Clock.getCurrentTime'
+'show' __t₀__
+@
+@
+"2016-04-06 03:50:11.159991 UTC"
+@
+
+===== What date and time is it in my local time zone, formatted to my default locale?
+
+@
+import "Control.Lens"
+import "System.Locale"
+import "Data.Thyme.LocalTime"
+import "Data.Thyme.Format"
+
+tz <- 'Data.Thyme.LocalTime.getCurrentTimeZone'
+'Data.Thyme.Format.formatTime' 'System.Locale.defaultTimeLocale' \"%c\" $ (tz, __t₀__) 'Control.Lens.Operators.^.' 'Data.Thyme.LocalTime.zonedTime'
+@
+@
+"Wed Apr  6 12:50:11 JST 2016"
+@
+
+===== What wall-clock time will it be /1000/ seconds from now?
+
+@
+import "Data.AffineSpace"
+
+(tz, __t₀__ 'Data.AffineSpace.+^' 'Data.Thyme.Clock.fromSeconds'' 1000) 'Control.Lens.Operators.^.' 'Data.Thyme.LocalTime.zonedTime' . 'Data.Thyme.LocalTime._zonedTimeToLocalTime' . 'Data.Thyme.LocalTime._localTimeOfDay'
+@
+@
+13:06:51.159991
+@
+
+===== About how long has it been since the Unix Era began at the Unix Epoch of /midnight, January first, 1970/?
+
+@
+import "Data.Thyme.Format.Human"
+import "Data.Thyme.Time.Core"
+
+"We are about " ++ 'Data.Thyme.Format.Human.humanTimeDiff' (__t₀__ 'Data.AffineSpace..-.' 'Data.Thyme.Time.Core.mkUTCTime' ('Data.Thyme.Time.Core.fromGregorian' 1970 1 1) ('Data.Thyme.Clock.hhmmss' 0 0 0)) ++ " into the Unix Era."
+@
+@
+"We are about 5 decades into the Unix Era."
+@
+
+===== Two months from today, what day of the week will it be?
+
+@
+import "Data.Thyme.Calendar"
+
+'Data.Thyme.Format.formatTime' 'System.Locale.defaultTimeLocale' \"%A\" $ 'Control.Lens.Getter.view' 'Data.Thyme.Calendar.WeekDate.weekDate' $ 'Control.Lens.Setter.over' 'Data.Thyme.Calendar.gregorian' ('Data.Thyme.Calendar.gregorianMonthsClip' 2) $ 'Control.Lens.Getter.view' 'Data.Thyme.Clock._utctDay' __t₀__
+@
+@
+\"Monday\"
+@
+
+-}
 
 module Data.Thyme
     ( module Data.Thyme.Calendar
@@ -34,4 +117,3 @@ import Data.Thyme.Calendar
 import Data.Thyme.Clock
 import Data.Thyme.Format
 import Data.Thyme.LocalTime
-

--- a/src/Data/Thyme/Calendar.hs
+++ b/src/Data/Thyme/Calendar.hs
@@ -13,12 +13,14 @@
 -- calculations by themselves work perfectly fine for a wider range of
 -- dates, subject to the size of 'Int' for your platform.
 module Data.Thyme.Calendar
-    ( Years, Months, Days
-    -- * Days
-    , Day (..), modifiedJulianDay
-    -- * Gregorian calendar
-    , Year, Month, DayOfMonth
+    (
+    -- * Calendar
+      Year, Month, DayOfMonth
     , YearMonthDay (..)
+    , Years, Months, Days
+    -- * Proleptic Modified Julian Day
+    , Day (..), modifiedJulianDay
+    -- * Proleptic Gregorian Calendar
     , isLeapYear
     , yearMonthDay, gregorian, gregorianValid, showGregorian
     , module Data.Thyme.Calendar
@@ -74,16 +76,49 @@ instance CoArbitrary YearMonthDay where
 
 ------------------------------------------------------------------------
 
+-- | The number of days in a given month according to the
+-- <https://en.wikipedia.org/wiki/Proleptic_Gregorian_calendar proleptic Gregorian calendar>.
+--
+-- ==== Examples
+--
+-- @
+-- > 'gregorianMonthLength' 2005 2
+--   28
+-- @
 {-# INLINE gregorianMonthLength #-}
 gregorianMonthLength :: Year -> Month -> Days
 gregorianMonthLength = monthLength . isLeapYear
 
+-- | Add months, with days past the last day of the month clipped to the last
+-- day, according to the
+-- <https://en.wikipedia.org/wiki/Proleptic_Gregorian_calendar proleptic Gregorian calendar>.
+--
+-- See also 'Data.Thyme.Time.Core.addGregorianMonthsClip'.
+--
+-- ==== Examples
+--
+-- @
+-- > 'gregorianMonthsClip' 1 $ 'YearMonthDay' 2005 1 30
+--   'YearMonthDay' {ymdYear = 2005, ymdMonth = 2, ymdDay = 28}
+-- @
 {-# INLINEABLE gregorianMonthsClip #-}
 gregorianMonthsClip :: Months -> YearMonthDay -> YearMonthDay
 gregorianMonthsClip n (YearMonthDay y m d) = YearMonthDay y' m'
         $ min (gregorianMonthLength y' m') d where
     ((+) y -> y', (+) 1 -> m') = divMod (m + n - 1) 12
 
+-- | Add months, with days past the last day of the month rolling over to the
+-- next month, according to the
+-- <https://en.wikipedia.org/wiki/Proleptic_Gregorian_calendar proleptic Gregorian calendar>.
+--
+-- See also 'Data.Thyme.Time.Core.addGregorianMonthsRollover'.
+--
+-- ==== Examples
+--
+-- @
+-- > 'gregorianMonthsRollover' 1 $ 'YearMonthDay' 2005 1 30
+--   'YearMonthDay' {ymdYear = 2005, ymdMonth = 3, ymdDay = 2}
+-- @
 {-# ANN gregorianMonthsRollover "HLint: ignore Use if" #-}
 {-# INLINEABLE gregorianMonthsRollover #-}
 gregorianMonthsRollover :: Months -> YearMonthDay -> YearMonthDay
@@ -96,12 +131,36 @@ gregorianMonthsRollover n (YearMonthDay y m d) = case d <= len of
     ((+) y -> y', (+) 1 -> m') = divMod (m + n - 1) 12
     len = gregorianMonthLength y' m'
 
+-- | Add years, matching month and day, with /Feb 29th/ clipped to /Feb 28th/ if
+-- necessary, according to the
+-- <https://en.wikipedia.org/wiki/Proleptic_Gregorian_calendar proleptic Gregorian calendar>.
+--
+-- See also 'Data.Thyme.Time.Core.addGregorianYearsClip'.
+--
+-- ==== Examples
+--
+-- @
+-- > 'gregorianYearsClip' 2 $ 'YearMonthDay' 2004 2 29
+--   'YearMonthDay' {ymdYear = 2006, ymdMonth = 2, ymdDay = 28}
+-- @
 {-# INLINEABLE gregorianYearsClip #-}
 gregorianYearsClip :: Years -> YearMonthDay -> YearMonthDay
 gregorianYearsClip n (YearMonthDay ((+) n -> y') 2 29)
     | not (isLeapYear y') = YearMonthDay y' 2 28
 gregorianYearsClip n (YearMonthDay y m d) = YearMonthDay (y + n) m d
 
+-- | Add years, matching month and day, with /Feb 29th/ rolled over to /Mar 1st/ if
+-- necessary, according to the
+-- <https://en.wikipedia.org/wiki/Proleptic_Gregorian_calendar proleptic Gregorian calendar>.
+--
+-- See also 'Data.Thyme.Time.Core.addGregorianYearsRollover'.
+--
+-- ==== Examples
+--
+-- @
+-- > 'gregorianYearsRollover' 2 $ 'YearMonthDay' 2004 2 29
+--   'YearMonthDay' {ymdYear = 2006, ymdMonth = 3, ymdDay = 1}
+-- @
 {-# INLINEABLE gregorianYearsRollover #-}
 gregorianYearsRollover :: Years -> YearMonthDay -> YearMonthDay
 gregorianYearsRollover n (YearMonthDay ((+) n -> y') 2 29)
@@ -109,6 +168,7 @@ gregorianYearsRollover n (YearMonthDay ((+) n -> y') 2 29)
 gregorianYearsRollover n (YearMonthDay y m d) = YearMonthDay (y + n) m d
 
 -- * Lenses
+
 LENS(YearMonthDay,ymdYear,Year)
 LENS(YearMonthDay,ymdMonth,Month)
 LENS(YearMonthDay,ymdDay,DayOfMonth)

--- a/src/Data/Thyme/Calendar/Internal.hs
+++ b/src/Data/Thyme/Calendar/Internal.hs
@@ -45,12 +45,47 @@ import GHC.Generics (Generic)
 import System.Random
 import Test.QuickCheck hiding ((.&.))
 
+-- | Duration of years.
 type Years = Int
+
+-- | Duration of months.
 type Months = Int
+
+-- | Duration of days.
 type Days = Int
 
--- | The Modified Julian Day is a standard count of days, with zero being
--- the day 1858-11-17.
+-- | A date, represented as a count of days since the
+-- <https://en.wikipedia.org/wiki/Julian_day#Variants Modified Julian Day>
+-- epoch, /1858-11-17/.
+--
+-- 'Day' is an instance of 'Data.AffineSpace.AffineSpace'
+-- where @'Diff' 'Day' = 'Days'@, so arithmetic on 'Day' and 'Days' can be
+-- performed with the '.-.', '.+^', and '.-^' operators.
+--
+-- To decompose a 'Day' calendar date into years, months, and days, use
+-- the Iso 'gregorian'.
+--
+-- ==== Examples
+--
+-- @
+-- > 'Data.Thyme.Time.Core.fromGregorian' 2016 3 1
+--   2016-03-01
+-- @
+--
+-- @
+-- > 'gregorian' 'Control.Lens.Review.#' 'YearMonthDay' 2016 3 1
+--   2016-03-01
+-- @
+--
+-- @
+-- > import "Data.AffineSpace"
+--
+-- > 'Data.Thyme.Time.Core.fromGregorian' 2016 3 1 'Data.AffineSpace..-.' 'Data.Thyme.Time.Core.fromGregorian' 2016 2 1
+--   29
+--
+-- > 'Data.Thyme.Time.Core.fromGregorian' 2016 3 1 'Data.AffineSpace..-^' 1
+--   2016-02-29
+-- @
 newtype Day = ModifiedJulianDay
     { toModifiedJulianDay :: Int
     } deriving (INSTANCES_NEWTYPE, CoArbitrary)
@@ -62,10 +97,39 @@ instance AffineSpace Day where
     {-# INLINE (.+^) #-}
     (.+^) = \ (ModifiedJulianDay a) d -> ModifiedJulianDay (a + d)
 
+-- | "Control.Lens.Iso" between Modified Julian 'Day' and 'Int'
+--
+-- ==== Examples
+--
+-- @
+-- > 'Data.Thyme.Time.Core.fromGregorian' 1858 11 17 '^.' 'modifiedJulianDay'
+--   0
+-- @
+--
+-- @
+-- > 'modifiedJulianDay' 'Control.Lens.Review.#' 0
+--   1858-11-17
+-- @
+
 {-# INLINE modifiedJulianDay #-}
 modifiedJulianDay :: Iso' Day Int
 modifiedJulianDay = iso toModifiedJulianDay ModifiedJulianDay
 
+-- | "Control.Lens.Iso" between ordinal date and
+-- <https://en.wikipedia.org/wiki/Proleptic_Gregorian_calendar proleptic Gregorian calendar>
+-- date.
+--
+-- ==== Examples
+--
+-- @
+-- > 'OrdinalDate' 2016 32 '^.' 'yearMonthDay'
+--   'YearMonthDay' {ymdYear = 2016, ymdMonth = 2, ymdDay = 1}
+-- @
+--
+-- @
+-- > 'yearMonthDay' 'Control.Lens.Review.#' 'YearMonthDay' 2016 2 1
+--   'OrdinalDate' {odYear = 2016, odDay = 32}
+-- @
 {-# INLINE yearMonthDay #-}
 yearMonthDay :: Iso' OrdinalDate YearMonthDay
 yearMonthDay = iso fromOrdinal toOrdinal where
@@ -80,15 +144,59 @@ yearMonthDay = iso fromOrdinal toOrdinal where
     toOrdinal (YearMonthDay y m d) = OrdinalDate y $
         monthDay (isLeapYear y) # MonthDay m d
 
+-- | "Control.Lens.Iso" between Modified Julian 'Day' and
+-- <https://en.wikipedia.org/wiki/Proleptic_Gregorian_calendar proleptic Gregorian calendar>
+-- date.
+--
+-- @
+-- gregorian ≡ 'ordinalDate' . 'yearMonthDay'
+-- @
+--
+-- See also 'Data.Thyme.Time.Core.fromGregorian',
+-- 'Data.Thyme.Time.Core.fromGregorianValid',
+-- 'Data.Thyme.Time.Core.toGregorian'.
+--
+-- ==== Examples
+--
+-- @
+-- > 'ModifiedJulianDay' 0 '^.' 'gregorian'
+--   'YearMonthDay' {ymdYear = 1858, ymdMonth = 11, ymdDay = 17}
+-- @
+--
+-- @
+-- > 'gregorian' 'Control.Lens.Review.#' 'YearMonthDay' 1858 11 17
+--   1858-11-17
+-- @
 {-# INLINE gregorian #-}
 gregorian :: Iso' Day YearMonthDay
 gregorian = ordinalDate . yearMonthDay
 
+-- | Convert from
+-- <https://en.wikipedia.org/wiki/Proleptic_Gregorian_calendar proleptic Gregorian calendar>
+-- date to Modified Julian 'Day'.
+-- Invalid Gregorian dates will return 'Nothing'.
+--
+-- ==== Examples
+--
+-- @
+-- > 'gregorianValid' ('YearMonthDay' 2015 2 28)
+--   Just 2015-02-28
+-- @
+--
+-- @
+-- > 'gregorianValid' ('YearMonthDay' 2015 2 29)
+--   Nothing
+-- @
 {-# INLINEABLE gregorianValid #-}
 gregorianValid :: YearMonthDay -> Maybe Day
 gregorianValid (YearMonthDay y m d) = review ordinalDate . OrdinalDate y
     <$> monthDayValid (isLeapYear y) (MonthDay m d)
 
+-- | 'Show' a Modified Julian 'Day' as a
+-- <https://en.wikipedia.org/wiki/Proleptic_Gregorian_calendar proleptic Gregorian calendar>
+-- date. /YYYY-MM-DD/
+--
+-- See also 'Data.Thyme.Format.formatTime'.
 {-# INLINEABLE showGregorian #-}
 showGregorian :: Day -> String
 showGregorian (view gregorian -> YearMonthDay y m d) =
@@ -102,10 +210,16 @@ instance Show Day where show = showGregorian
 
 ------------------------------------------------------------------------
 
+-- | Calendar year.
 type Year = Int
+
+-- | Calendar month. /January = 1/
 type Month = Int
+
+-- | Calendar day-of-month. Starting from /1/.
 type DayOfMonth = Int
 
+-- | A date on the calendar.
 data YearMonthDay = YearMonthDay
     { ymdYear :: {-# UNPACK #-}!Year
     , ymdMonth :: {-# UNPACK #-}!Month
@@ -117,12 +231,18 @@ instance NFData YearMonthDay
 
 ------------------------------------------------------------------------
 
--- | Gregorian leap year?
+-- | Is this year a
+-- <https://en.wikipedia.org/wiki/Proleptic_Gregorian_calendar proleptic Gregorian calendar>
+-- leap year?
 isLeapYear :: Year -> Bool
 isLeapYear y = y .&. 3 == 0 && (r100 /= 0 || q100 .&. 3 == 0) where
     (q100, r100) = y `quotRem` 100
 
+-- | The day of the year, with /1 = January 1st/.
 type DayOfYear = Int
+
+-- | An
+-- <https://en.wikipedia.org/wiki/ISO_8601#Ordinal_dates ISO 8601 Ordinal Date>.
 data OrdinalDate = OrdinalDate
     { odYear :: {-# UNPACK #-}!Year
     , odDay :: {-# UNPACK #-}!DayOfYear
@@ -131,38 +251,62 @@ data OrdinalDate = OrdinalDate
 instance Hashable OrdinalDate
 instance NFData OrdinalDate
 
--- Brief description of the toOrdinal computation.
+-- | "Control.Lens.Iso" to convert between the Modified Julian 'Day' and
+-- 'OrdinalDate'.
 --
--- The length of the years in Gregorian calendar is periodic with
--- period of 400 years. There are 100 - 4 + 1 = 97 leap years in a
--- period, so the average length of a year is 365 + 97/400 =
--- 146097/400 days.
+-- See also 'Data.Thyme.Calendar.ordinalDateValid'.
 --
--- Now, if you consider these -- let's call them nominal -- years,
+-- ==== Examples
+--
+-- @
+-- > 'ordinalDate' 'Control.Lens.Review.#' 'OrdinalDate' 2016 32
+--   2016-02-01
+-- @
+--
+-- @
+-- > 'toModifiedJulianDay' $ 'ordinalDate' 'Control.Lens.Review.#' 'OrdinalDate' 2016 32
+--   57419
+-- @
+--
+-- @
+-- > 'ModifiedJulianDay' 57419 '^.' 'ordinalDate'
+--   'OrdinalDate' {odYear = 2016, odDay = 32}
+-- @
+--
+-- === Brief description of the 'ordinalDate' computation
+--
+-- The length of the years in the
+-- <https://en.wikipedia.org/wiki/Proleptic_Gregorian_calendar proleptic Gregorian calendar>
+-- is periodic with
+-- period of /400/ years. There are /100 - 4 + 1 = 97/ leap years in a
+-- period, so the average length of a year is
+-- /365 + 97\/400 = 146097\/400/ days.
+--
+-- Now, if you consider these — let's call them nominal — years,
 -- then for any point in time, for any linear day number we can
 -- determine which nominal year does it fall into by a single
--- division. Moreover, if we align the start of the calendar year 1
--- with the start of the nominal year 1, then the calendar years and
+-- division. Moreover, if we align the start of the calendar year /1/
+-- with the start of the nominal year /1/, then the calendar years and
 -- nominal years never get too much out of sync. Specifically:
 --
---  * start of the first day of a calendar year might fall into the
---    preceding nominal year, but never more than by 1.5 days (591/400
---    days, to be precise)
---  * the start of the last day of a calendar year always falls into
+--  * The start of the first day of a calendar year might fall into the
+--    preceding nominal year, but never more than by /1.5/ days (/591\/400/
+--    days, to be precise).
+--
+--  * The start of the last day of a calendar year always falls into
 --    its nominal year (even for the leap years).
 --
 -- So, to find out the calendar year for a given day, we calculate
--- which nominal year does its start fall. And, if we are not too
+-- on which nominal year does its start fall. And, if we are not too
 -- close to the end of year, we have the right calendar
 -- year. Othewise, we just check whether it falls within the next
 -- calendar year.
 --
 -- Notes: to make the reasoning simpler and more efficient ('quot' is
 -- faster than 'div') we do the computation directly only for positive
--- years (days after 1-1-1). For earlier dates we "transate" by an
--- integral number of 400 year periods, do the computation and
+-- years (days after /1-1-1/). For earlier dates we translate by an
+-- integral number of /400/ year periods, do the computation and
 -- translate back.
-
 {-# INLINE ordinalDate #-}
 ordinalDate :: Iso' Day OrdinalDate
 ordinalDate = iso toOrd fromOrd where
@@ -243,6 +387,7 @@ randomIsoR l (x, y) = first (^. l) . randomR (l # x, l # y)
 
 ------------------------------------------------------------------------
 
+-- | A month and day-of-month.
 data MonthDay = MonthDay
     { mdMonth :: {-# UNPACK #-}!Month
     , mdDay :: {-# UNPACK #-}!DayOfMonth
@@ -267,10 +412,44 @@ instance Arbitrary MonthDay where
 instance CoArbitrary MonthDay where
     coarbitrary (MonthDay m d) = coarbitrary m . coarbitrary d
 
--- | Convert between day of year in the Gregorian or Julian calendars, and
--- month and day of month. First arg is leap year flag.
+-- | Predicated on whether or not the year is a leap year, produces a
+-- "Control.Lens.Iso" to convert between ordinal day of year in the Gregorian or
+-- Julian calendars, and month and day of month.
+--
+-- ==== Examples
+--
+-- @
+-- > 60 '^.' 'monthDay' ('isLeapYear' 2015)
+--   'MonthDay' {mdMonth = 3, mdDay = 1}
+-- @
+--
+-- @
+-- > 60 '^.' 'monthDay' ('isLeapYear' 2016)
+--   'MonthDay' {mdMonth = 2, mdDay = 29}
+-- @
+--
+-- @
+-- > monthDay ('isLeapYear' 2016) 'Control.Lens.Review.#' 'MonthDay' 2 29
+--   60
+-- @
+--
+-- @
+-- > monthDay ('isLeapYear' 2015) 'Contrl.Lens.Review.#' 'MonthDay' 2 28
+--   59
+-- @
+--
+-- Note that 'monthDay' is an improper 'Iso'', as the following example shows.
+-- To handle this case correctly, use 'monthDayValid'.
+--
+-- @
+-- > monthDay ('isLeapYear' 2015) 'Control.Lens.Review.#' 'MonthDay' 2 29
+--   59
+-- @
 {-# INLINE monthDay #-}
-monthDay :: Bool -> Iso' DayOfYear MonthDay
+monthDay
+    :: Bool
+        -- ^ 'isLeapYear'?
+    -> Iso' DayOfYear MonthDay
 monthDay leap = iso fromOrdinal toOrdinal where
     (lastDay, lengths, table, ok) = if leap
         then (365, monthLengthsLeap, monthDaysLeap, -1)
@@ -289,33 +468,107 @@ monthDay leap = iso fromOrdinal toOrdinal where
         d = max 1 . min l $ day
         k = if m <= 2 then 0 else ok
 
+-- | Predicated on whether or not the year is a leap year, convert a
+-- 'MonthDay' to a 'DayOfYear'.
+--
+-- ==== Examples
+--
+-- @
+-- > monthDayValid ('isLeapYear' 2016) ('MonthDay' 2 29)
+--   Just 60
+-- @
+--
+-- @
+-- > monthDayValid ('isLeapYear' 2015) ('MonthDay' 2 29)
+--   Nothing
+-- @
 {-# INLINEABLE monthDayValid #-}
-monthDayValid :: Bool -> MonthDay -> Maybe DayOfYear
+monthDayValid
+    :: Bool
+        -- ^ 'isLeapYear'?
+    -> MonthDay
+    -> Maybe DayOfYear
 monthDayValid leap md@(MonthDay m d) = monthDay leap # md
     <$ guard (1 <= m && m <= 12 && 1 <= d && d <= monthLength leap m)
 
+-- | Predicated on whether or not the year is a leap year, return the number
+-- of 'Days' in the given 'Month'.
+--
+-- ==== Examples
+--
+-- @
+-- > monthLength ('isLeapYear' 2015) 2
+--   28
+-- @
+--
+-- @
+-- > monthLength ('isLeapYear' 2016) 2
+--   29
+-- @
 {-# INLINEABLE monthLength #-}
-monthLength :: Bool -> Month -> Days
+monthLength
+    :: Bool
+        -- ^ 'isLeapYear'?
+    -> Month
+    -> Days
 monthLength leap = VU.unsafeIndex ls . max 0 . min 11 . pred where
     ls = if leap then monthLengthsLeap else monthLengths
 
 ------------------------------------------------------------------------
 
+-- | Week of the year. Meaning of values depends on context. For meaning
+-- see 'wdWeek', 'swWeek', 'mwWeek'.
 type WeekOfYear = Int
+
+-- | Day of the week.
+--
+-- Possible values:
+--
+-- [/0/] /Sunday/ (for 'SundayWeek')
+--
+-- [/1/] /Monday/
+--
+-- [/2/] /Tuesday/
+--
+-- [/3/] /Wednesday/
+--
+-- [/4/] /Thursday/
+--
+-- [/5/] /Friday/
+--
+-- [/6/] /Saturday/
+--
+-- [/7/] /Sunday/ (for 'WeekDate' and 'MondayWeek' and 'Data.Thyme.Calendar.WeekdayOfMonth')
 type DayOfWeek = Int
 
--- | Weeks numbered 01 to 53, where week 01 is the first week that has at
--- least 4 days in the new year. Days before week 01 are considered to
--- belong to the previous year.
+-- | <https://en.wikipedia.org/wiki/ISO_8601#Week_dates ISO 8601 Week Date>.
+--
+-- Note that 'WeekDate' years are
+-- not quite the same as Gregorian years, as the first day of the year is always
+-- a /Monday/. The first week of a year is the first week to contain at least
+-- four days in the corresponding Gregorian year.
 data WeekDate = WeekDate
     { wdYear :: {-# UNPACK #-}!Year
     , wdWeek :: {-# UNPACK #-}!WeekOfYear
+        -- ^ Weeks numbered /1/ to /53/, where week /1/ is the first week that
+        -- has at least /4/ days in the new year. Days before week /1/ are
+        -- considered to belong to the previous year.
     , wdDay :: {-# UNPACK #-}!DayOfWeek
+        -- ^ /1 = Monday, 7 = Sunday/.
     } deriving (INSTANCES_USUAL, Show)
 
 instance Hashable WeekDate
 instance NFData WeekDate
 
+-- | "Control.Lens.Iso" for converting between Modified Julian 'Day' and ISO 8601
+-- Week Date format.
+--
+-- ==== Examples
+--
+-- @
+-- > 'Data.Thyme.Time.Core.fromGregorian' 2016 1 1 '^.' 'weekDate'
+--   'WeekDate' {wdYear = 2015, wdWeek = 53, wdDay = 5}
+-- @
 {-# INLINE weekDate #-}
 weekDate :: Iso' Day WeekDate
 weekDate = iso toWeek fromWeek where
@@ -358,11 +611,13 @@ fromWeekLast wMax (WeekDate y w d) = ModifiedJulianDay mjd where
     mjd = k - mod k 7 - 10 + clip 1 7 d + clip 1 wMax w * 7
     clip a b = max a . min b
 
+-- | Convert a 'WeekDate' to a 'Day', or 'Nothing' for invalid 'WeekDate'.
 {-# INLINEABLE weekDateValid #-}
 weekDateValid :: WeekDate -> Maybe Day
 weekDateValid wd@(WeekDate (lastWeekOfYear -> wMax) w d) =
     fromWeekLast wMax wd <$ guard (1 <= d && d <= 7 && 1 <= w && w <= wMax)
 
+-- | 'Show' in ISO 8601 Week Date format as yyyy-Www-d (e.g. "2006-W46-3").
 {-# INLINEABLE showWeekDate #-}
 showWeekDate :: Day -> String
 showWeekDate (view weekDate -> WeekDate y w d) =
@@ -370,19 +625,32 @@ showWeekDate (view weekDate -> WeekDate y w d) =
 
 ------------------------------------------------------------------------
 
--- | Weeks numbered from 0 to 53, starting with the first Sunday of the year
--- as the first day of week 1. The last week of a given year and week 0 of
--- the next both refer to the same week, but not all 'DayOfWeek' are valid.
--- 'Year' coincides with that of 'gregorian'.
+-- | Week-based calendar date with the first /Sunday/ of the year as the first
+-- day of week /1/.
+--
+-- The last week of a given year and week /0/ of the next both refer to the
+-- same week, but not all 'DayOfWeek' are valid.
 data SundayWeek = SundayWeek
     { swYear :: {-# UNPACK #-}!Year
+        -- ^ Coincides with that of 'gregorian'.
     , swWeek :: {-# UNPACK #-}!WeekOfYear
+        -- ^ Weeks numbered from /0/ to /53/, starting with the first /Sunday/
+        -- of the year as the first day of week /1/.
     , swDay :: {-# UNPACK #-}!DayOfWeek
+        -- ^ /0 = Sunday, 6 = Saturday/.
     } deriving (INSTANCES_USUAL, Show)
 
 instance Hashable SundayWeek
 instance NFData SundayWeek
 
+-- | "Control.Lens.Iso" between 'Day' and 'SundayWeek'.
+--
+-- ==== Examples
+--
+-- @
+-- > 'Data.Thyme.Time.Core.fromGregorian' 2016 1 3 '^.' 'sundayWeek'
+--   SundayWeek {swYear = 2016, swWeek = 1, swDay = 0}
+-- @
 {-# INLINE sundayWeek #-}
 sundayWeek :: Iso' Day SundayWeek
 sundayWeek = iso toSunday fromSunday where
@@ -407,6 +675,7 @@ toSundayOrdinal (OrdinalDate y yd) (ModifiedJulianDay mjd) =
     k = d - yd
     (d7div, d7mod) = divMod d 7
 
+-- | Convert a 'SundayWeek' to a 'Day', or 'Nothing' for invalid 'SundayWeek'.
 {-# INLINEABLE sundayWeekValid #-}
 sundayWeekValid :: SundayWeek -> Maybe Day
 sundayWeekValid (SundayWeek y w d) = ModifiedJulianDay (firstDay + yd)
@@ -419,19 +688,32 @@ sundayWeekValid (SundayWeek y w d) = ModifiedJulianDay (firstDay + yd)
 
 ------------------------------------------------------------------------
 
--- | Weeks numbered from 0 to 53, starting with the first Monday of the year
--- as the first day of week 1. The last week of a given year and week 0 of
--- the next both refer to the same week, but not all 'DayOfWeek' are valid.
--- 'Year' coincides with that of 'gregorian'.
+-- | Week-based calendar date with the first /Monday/ of the year as the
+-- first day of week /1/.
+--
+-- The last week of a given year and week /0/ of the next both refer to
+-- the same week, but not all 'DayOfWeek' are valid.
 data MondayWeek = MondayWeek
     { mwYear :: {-# UNPACK #-}!Year
+        -- ^ Coincides with that of 'gregorian'.
     , mwWeek :: {-# UNPACK #-}!WeekOfYear
+        -- ^ Weeks numbered from /0/ to /53/, starting with the first /Monday/
+        -- of the year as the first day of week /1/.
     , mwDay :: {-# UNPACK #-}!DayOfWeek
+        -- ^ /1 = Monday, 7 = Sunday/.
     } deriving (INSTANCES_USUAL, Show)
 
 instance Hashable MondayWeek
 instance NFData MondayWeek
 
+-- | "Control.Lens.Iso" between 'Day' and 'MondayWeek'.
+--
+-- ==== Examples
+--
+-- @
+-- > 'Data.Thyme.Time.Core.fromGregorian' 2016 1 3 '^.' 'mondayWeek'
+--   'MondayWeek' {mwYear = 2016, mwWeek = 0, mwDay = 7}
+-- @
 {-# INLINE mondayWeek #-}
 mondayWeek :: Iso' Day MondayWeek
 mondayWeek = iso toMonday fromMonday where
@@ -456,6 +738,7 @@ toMondayOrdinal (OrdinalDate y yd) (ModifiedJulianDay mjd) =
     k = d - yd
     (d7div, d7mod) = divMod d 7
 
+-- | Convert a 'MondayWeek' to a 'Day', or 'Nothing' for invalid 'MondayWeek'.
 {-# INLINEABLE mondayWeekValid #-}
 mondayWeekValid :: MondayWeek -> Maybe Day
 mondayWeekValid (MondayWeek y w d) = ModifiedJulianDay (firstDay + yd)

--- a/src/Data/Thyme/Calendar/MonthDay.hs
+++ b/src/Data/Thyme/Calendar/MonthDay.hs
@@ -2,7 +2,9 @@
 {-# LANGUAGE RecordWildCards #-}
 #include "thyme.h"
 
--- | Julian or Gregorian.
+{-|
+Calendar months and day-of-months.
+-}
 module Data.Thyme.Calendar.MonthDay
     ( Month, DayOfMonth, MonthDay (..)
     , monthDay, monthDayValid, monthLength

--- a/src/Data/Thyme/Calendar/OrdinalDate.hs
+++ b/src/Data/Thyme/Calendar/OrdinalDate.hs
@@ -41,6 +41,24 @@ instance Arbitrary OrdinalDate where
 instance CoArbitrary OrdinalDate where
     coarbitrary (OrdinalDate y d) = coarbitrary y . coarbitrary d
 
+-- | Is this a valid ordinal date?
+--
+-- ==== Examples
+--
+-- @
+-- > ordinalDateValid ('OrdinalDate' 2015 365)
+--   Just 2015-12-31
+-- @
+--
+-- @
+-- > ordinalDateValid ('OrdinalDate' 2015 366)
+--   Nothing
+-- @
+--
+-- @
+-- > ordinalDateValid ('OrdinalDate' 2016 366)
+--   Just 2016-12-31
+-- @
 {-# INLINE ordinalDateValid #-}
 ordinalDateValid :: OrdinalDate -> Maybe Day
 ordinalDateValid od@(OrdinalDate y d) = ordinalDate # od

--- a/src/Data/Thyme/Clock.hs
+++ b/src/Data/Thyme/Clock.hs
@@ -17,27 +17,14 @@ their stead are instances of 'Data.AdditiveGroup.AdditiveGroup',
 @'Data.VectorSpace.Scalar' 'DiffTime' ≡ 'Data.VectorSpace.Scalar'
 'NominalDiffTime' ≡ 'Rational'@.
 
- Using 'fromSeconds' and 'toSeconds' to convert between 'TimeDiff's and
- other numeric types. If you really must coerce between 'DiffTime' and
- 'NominalDiffTime', @'view' ('microseconds' . 'from' 'microseconds')@.
-
-'UTCTime' is an instance of 'Data.AffineSpace.AffineSpace', with
-@'Data.AffineSpace.Diff' 'UTCTime' ≡ 'NominalDiffTime'@.
-
-'UTCTime' is not Y294K-compliant. Please file a bug report on GitHub when
-this becomes a problem.
+Using 'fromSeconds' and 'toSeconds' to convert between 'TimeDiff's and
+other numeric types. If you really must coerce between 'DiffTime' and
+'NominalDiffTime', @'view' ('microseconds' . 'from' 'microseconds')@.
 -}
 
 module Data.Thyme.Clock (
-    -- * Universal Time
-      UniversalTime
-    , modJulianDate
-
-    -- * Absolute intervals
-    , DiffTime
-
     -- * UTC
-    , UTCTime
+      UTCTime
 #if __GLASGOW_HASKELL__ >= 708
     , pattern UTCTime
 #endif
@@ -47,11 +34,18 @@ module Data.Thyme.Clock (
     , NominalDiffTime
     , module Data.Thyme.Clock
 
+    -- * Absolute intervals
+    , DiffTime
+
     -- * Time interval conversion
     , TimeDiff (..)
     , toSeconds, fromSeconds
     , toSeconds', fromSeconds'
     , hhmmss
+
+    -- * Universal Time
+    , UniversalTime
+    , modJulianDate
 
     -- * Lenses
     , _utcvDay, _utcvDayTime

--- a/src/Data/Thyme/Clock.hs
+++ b/src/Data/Thyme/Clock.hs
@@ -3,29 +3,30 @@
 {-# LANGUAGE PatternSynonyms #-}
 #endif
 
--- | Types and functions for
--- <http://en.wikipedia.org/wiki/Coordinated_Universal_Time UTC> and
--- <http://en.wikipedia.org/wiki/Universal_Time#Versions UT1>.
---
--- If you don't care about leap seconds, keep to 'UTCTime' and
--- 'NominalDiffTime' for your clock calculations, and you'll be fine.
---
--- 'Num', 'Real', 'Fractional' and 'RealFrac' instances for 'DiffTime' and
--- 'NominalDiffTime' are only available by importing "Data.Thyme.Time". In
--- their stead are instances of 'Data.AdditiveGroup.AdditiveGroup',
--- 'Data.Basis.HasBasis' and 'Data.VectorSpace.VectorSpace', with
--- @'Data.VectorSpace.Scalar' 'DiffTime' ≡ 'Data.VectorSpace.Scalar'
--- 'NominalDiffTime' ≡ 'Rational'@.
---
---  Using 'fromSeconds' and 'toSeconds' to convert between 'TimeDiff's and
---  other numeric types. If you really must coerce between 'DiffTime' and
---  'NominalDiffTime', @'view' ('microseconds' . 'from' 'microseconds')@.
---
--- 'UTCTime' is an instance of 'Data.AffineSpace.AffineSpace', with
--- @'Data.AffineSpace.Diff' 'UTCTime' ≡ 'NominalDiffTime'@.
---
--- 'UTCTime' is not Y294K-compliant. Please file a bug report on GitHub when
--- this becomes a problem.
+{-| Types and functions for
+<http://en.wikipedia.org/wiki/Coordinated_Universal_Time UTC> and
+<http://en.wikipedia.org/wiki/Universal_Time#Versions UT1>.
+
+If you don't care about leap seconds, keep to 'UTCTime' and
+'NominalDiffTime' for your clock calculations, and you'll be fine.
+
+'Num', 'Real', 'Fractional' and 'RealFrac' instances for 'DiffTime' and
+'NominalDiffTime' are only available by importing "Data.Thyme.Time". In
+their stead are instances of 'Data.AdditiveGroup.AdditiveGroup',
+'Data.Basis.HasBasis' and 'Data.VectorSpace.VectorSpace', with
+@'Data.VectorSpace.Scalar' 'DiffTime' ≡ 'Data.VectorSpace.Scalar'
+'NominalDiffTime' ≡ 'Rational'@.
+
+ Using 'fromSeconds' and 'toSeconds' to convert between 'TimeDiff's and
+ other numeric types. If you really must coerce between 'DiffTime' and
+ 'NominalDiffTime', @'view' ('microseconds' . 'from' 'microseconds')@.
+
+'UTCTime' is an instance of 'Data.AffineSpace.AffineSpace', with
+@'Data.AffineSpace.Diff' 'UTCTime' ≡ 'NominalDiffTime'@.
+
+'UTCTime' is not Y294K-compliant. Please file a bug report on GitHub when
+this becomes a problem.
+-}
 
 module Data.Thyme.Clock (
     -- * Universal Time
@@ -50,6 +51,7 @@ module Data.Thyme.Clock (
     , TimeDiff (..)
     , toSeconds, fromSeconds
     , toSeconds', fromSeconds'
+    , hhmmss
 
     -- * Lenses
     , _utcvDay, _utcvDayTime
@@ -61,7 +63,9 @@ import Control.Lens
 import Data.Thyme.Clock.Internal
 import Data.Thyme.Clock.POSIX
 
--- | Get the current UTC time from the system clock.
+-- | Get the current UTC date and time from the local system clock.
+--
+-- See also 'Data.Thyme.LocalTime.getZonedTime', 'Data.Thyme.Clock.POSIX.getPOSIXTime'.
 getCurrentTime :: IO UTCTime
 getCurrentTime = fmap (review posixTime) getPOSIXTime
 

--- a/src/Data/Thyme/Clock/Internal.hs
+++ b/src/Data/Thyme/Clock/Internal.hs
@@ -171,10 +171,12 @@ fromSecondsIntegral _ = review microseconds . (*) 1000000 . fromIntegral
 
 ------------------------------------------------------------------------
 
--- | An absolute time interval as measured by a clock.
+-- | An interval or duration of time, as would be measured by a stopwatch.
 --
--- 'DiffTime' forms an 'AdditiveGroup'―so can be added using '^+^' (or '^-^'
--- for subtraction), and also an instance of 'VectorSpace'―so can be scaled
+-- 'DiffTime' is an instance of 'AdditiveGroup', so it can be added with '^+^'
+-- or subtracted with '^-^'.
+--
+-- 'DiffTime' is an instance of 'VectorSpace', so it can be scaled
 -- using '*^', where
 --
 -- @
@@ -234,16 +236,18 @@ instance TimeDiff DiffTime where
 
 ------------------------------------------------------------------------
 
--- | A time interval as measured by UTC, that does not take leap-seconds
--- into account.
+-- | The nominal interval between two points of 'UTCTime' which does not
+-- take leap seconds into account.
 --
--- For instance, the difference between @23:59:59@ and @00:00:01@ on the
+-- For example, the difference between /23:59:59/ and /00:00:01/ on the
 -- following day is always 2 seconds of 'NominalDiffTime', regardless of
 -- whether a leap-second took place.
 --
--- 'NominalDiffTime' forms an 'AdditiveGroup'―so can be added using '^+^'
--- (or '^-^' for subtraction), and also an instance of 'VectorSpace'―so can
--- be scaled using '*^', where
+-- 'NominalDiffTime' is an instance of 'AdditiveGroup', so it can be added
+-- with '^+^' or subtracted with '^-^'.
+--
+-- 'NominalDiffTime' is an instance 'VectorSpace', so it can be scaled
+-- using '*^', where
 --
 -- @
 -- type 'Scalar' 'NominalDiffTime' = 'Rational'
@@ -321,17 +325,18 @@ posixDayLength = microseconds # 86400000000
 -- <http://en.wikipedia.org/wiki/Universal_Time#Versions UT1>.
 --
 -- 'UniversalTime' is defined by the rotation of the Earth around its axis
--- relative to the Sun. Thus the length of a day by this definition varies
--- from one to the next, and is never exactly 86400 SI seconds unlike
--- <http://en.wikipedia.org/wiki/International_Atomic_Time TAI> or
--- 'AbsoluteTime'. The difference between UT1 and UTC is
+-- relative to the Sun. The length of each UT1 day varies and is never
+-- exactly 86400 SI seconds, unlike
+-- 'UTCTime' or 'AbsoluteTime'.
+--
+-- The difference between UT1 and UTC is
 -- <http://en.wikipedia.org/wiki/DUT1 DUT1>.
 newtype UniversalTime = UniversalRep NominalDiffTime deriving (INSTANCES_MICRO)
 
 derivingUnbox "UniversalTime" [t| UniversalTime -> NominalDiffTime |]
     [| \ (UniversalRep a) -> a |] [| UniversalRep |]
 
--- | View 'UniversalTime' as a fractional number of days since the
+-- | Convert between 'UniversalTime' and the fractional number of days since the
 -- <http://en.wikipedia.org/wiki/Julian_day#Variants Modified Julian Date epoch>.
 {-# INLINE modJulianDate #-}
 modJulianDate :: Iso' UniversalTime Rational
@@ -362,6 +367,12 @@ modJulianDate = iso
 -- To translate a 'UTCTime' into a local zoned time, use
 -- the 'Data.Thyme.LocalTime.zonedTime' Iso.
 --
+-- To calculate the true absolute 'DiffTime' between two 'UTCTime's while
+-- accounting for leap seconds, first convert them to
+-- 'Data.Thyme.Clock.TAI.AbsoluteTime' by using
+-- the 'Data.Thyme.Clock.TAI.absoluteTime' Iso and
+-- then subtract with '.-.'.
+--
 -- ==== Performance
 --
 -- Internally this is a 64-bit count of 'microseconds' since
@@ -372,6 +383,8 @@ modJulianDate = iso
 --
 -- 'UTCTime' currently
 -- <https://github.com/liyang/thyme/issues/3 cannot represent leap seconds>.
+-- If leap seconds were supported, then the length of a day in 'UTCTime' could
+-- be /86399/, /86400/, or /86401/ seconds.
 --
 -- ==== Examples
 --

--- a/src/Data/Thyme/Clock/POSIX.hsc
+++ b/src/Data/Thyme/Clock/POSIX.hsc
@@ -4,6 +4,10 @@
 #include <sys/time.h>
 #endif
 
+{-|
+Native <https://en.wikipedia.org/wiki/Unix_time POSIX time>
+from @sys/time.h@. 
+-}
 module Data.Thyme.Clock.POSIX
     ( posixDayLength
     , POSIXTime
@@ -27,8 +31,21 @@ import Foreign.Ptr (Ptr, nullPtr)
 import Foreign.Storable
 #endif
 
+-- | Equivalent to
+-- a @<http://www.gnu.org/software/libc/manual/html_node/Elapsed-Time.html struct timeval>@.
 type POSIXTime = NominalDiffTime
 
+-- | "Control.Lens.Iso" between 'UTCTime' and 'POSIXTime'.
+--
+-- ==== Examples
+--
+-- @
+-- > getPOSIXTime 
+--   1459515013.527711s
+--
+-- > 'review' 'posixTime' \<$\> 'getPOSIXTime'
+--   2016-01-01 12:50:45.588729 UTC
+-- @
 {-# INLINE posixTime #-}
 posixTime :: Iso' UTCTime POSIXTime
 posixTime = iso (\ (UTCRep t) -> t ^-^ unixEpoch)
@@ -36,6 +53,12 @@ posixTime = iso (\ (UTCRep t) -> t ^-^ unixEpoch)
     unixEpoch = review microseconds $
         {-ModifiedJulianDay-}40587 * {-posixDayLength-}86400000000
 
+-- | Return the current system POSIX time
+-- from @<http://www.gnu.org/software/libc/manual/html_node/High_002dResolution-Calendar.html gettimeofday>@,
+-- or @getSystemTimeAsFileTime@ on Windows,
+-- or a similar call.
+-- 
+-- See also 'Data.Thyme.Clock.getCurrentTime', 'Data.Thyme.LocalTime.getZonedTime'.
 {-# INLINE getPOSIXTime #-}
 getPOSIXTime :: IO POSIXTime
 #ifdef mingw32_HOST_OS

--- a/src/Data/Thyme/Clock/TAI.hs
+++ b/src/Data/Thyme/Clock/TAI.hs
@@ -16,7 +16,7 @@
 #endif
 
 {-|
-<https://en.wikipedia.org/wiki/International_Atomic_Time Temps Atomique International>
+<https://en.wikipedia.org/wiki/International_Atomic_Time International Atomic Time>
 and leap-second support.
 -}
 module Data.Thyme.Clock.TAI
@@ -63,7 +63,14 @@ import System.Locale
 import System.Random (Random)
 import Test.QuickCheck
 
--- | TAI time as measured by a clock.
+-- | <https://en.wikipedia.org/wiki/International_Atomic_Time Temps Atomique International>,
+-- defined as the number of elapsed SI seconds since the
+-- <http://en.wikipedia.org/wiki/Julian_day#Variants Modified Julian Date epoch>,
+--
+-- TAI was synchronized with 'UTCTime' at the beginning of 1958, and in the
+-- intervening time have diverged due to leap second adjustments.
+--
+-- Note that for most applications 'UTCTime' is preferred.
 newtype AbsoluteTime = AbsoluteTime DiffTime deriving (INSTANCES_MICRO)
 
 derivingUnbox "AbsoluteTime" [t| AbsoluteTime -> DiffTime |]

--- a/src/Data/Thyme/Format/Human.hs
+++ b/src/Data/Thyme/Format/Human.hs
@@ -8,6 +8,9 @@
 #include "cabal_macros.h"
 #endif
 
+{-|
+Vague textual descriptions of time durations.
+-}
 module Data.Thyme.Format.Human
     ( humanTimeDiff
     , humanTimeDiffs

--- a/src/Data/Thyme/LocalTime.hs
+++ b/src/Data/Thyme/LocalTime.hs
@@ -353,7 +353,13 @@ dayFraction = from timeOfDay . iso toRatio fromRatio where
 
 -- | Local calendar date and time-of-day.
 --
--- To convert to UTC, see 'utcLocalTime'.
+-- This type is appropriate for inputting from and outputting to the
+-- outside world.
+--
+-- To actually perform logic and arithmetic on local date-times, a 'LocalTime'
+-- should first be converted to a 'UTCTime' by the 'utcLocalTime' Iso.
+--
+-- See also 'ZonedTime'.
 data LocalTime = LocalTime
     { localDay :: {-# UNPACK #-}!Day
         -- ^ Local calendar date.

--- a/src/Data/Thyme/Time/Core.hs
+++ b/src/Data/Thyme/Time/Core.hs
@@ -12,6 +12,17 @@
 -- | This module provides just the compatibility wrappers for the things
 -- that @thyme@ does differently from @time@. No 'RealFrac' instances for
 -- 'DiffTime' nor 'NominalDiffTime', nor other riffraff.
+--
+-- === References to @time@
+--
+-- * "Data.Time.Calendar"
+-- * "Data.Time.Calendar.MonthDay"
+-- * "Data.Time.Calendar.OrdinalDate"
+-- * "Data.Time.Calendar.WeekDate"
+-- * "Data.Time.Clock"
+-- * "Data.Time.Clock.POSIX"
+-- * "Data.Time.Clock.TAI"
+-- * "Data.Time.LocalTime"
 
 module Data.Thyme.Time.Core
     ( module Data.Thyme
@@ -41,7 +52,24 @@ import Unsafe.TrueName
 ------------------------------------------------------------------------
 -- * Type conversion
 
+-- | Typeclass for "Data.Thyme" types for which an "Control.Lens.Iso" exists
+-- to an equivalent type in the "Data.Time" library.
 class Thyme a b | b -> a where
+    -- | "Control.Lens.Iso" between "Data.Thyme" types and "Data.Time" types.
+    --
+    -- ==== Examples
+    --
+    -- @
+    -- > import qualified Data.Time
+    --
+    -- > :t 'thyme' 'Control.Lens.Review.#' ('fromSeconds'' 10 :: 'DiffTime')
+    --   'thyme' 'Control.Lens.Review.#' ('fromSeconds'' 10 :: 'DiffTime')
+    --     :: Data.Time.DiffTime
+    --
+    -- > :t Data.Time.Clock.secondsToDiffTime 10 '^.' 'thyme' :: 'DiffTime'
+    --   Data.Time.Clock.secondsToDiffTime 10 '^.' 'thyme' :: 'DiffTime'
+    --     :: 'DiffTime'
+    -- @
     thyme :: Iso' a b
 
 instance Thyme T.Day Day where
@@ -118,10 +146,16 @@ instance Thyme T.ZonedTime ZonedTime where
         (\ (T.ZonedTime t z) -> ZonedTime (t ^. thyme) (z ^. thyme))
         (\ (ZonedTime t z) -> T.ZonedTime (thyme # t) (thyme # z))
 
+-- | Convert from "Data.Time" type to "Data.Thyme" type.
+--
+-- See also 'thyme'.
 {-# INLINE toThyme #-}
 toThyme :: (Thyme a b) => a -> b
 toThyme = view thyme
 
+-- | Convert from "Data.Thyme" type to "Data.Time" type.
+--
+-- See also 'thyme'.
 {-# INLINE fromThyme #-}
 fromThyme :: (Thyme a b) => b -> a
 fromThyme = review thyme
@@ -129,41 +163,77 @@ fromThyme = review thyme
 ------------------------------------------------------------------------
 -- * @Data.Time.Calendar@
 
+-- | Add some 'Days' to a calendar 'Day' to get a new 'Day'.
+--
+-- See also 'Day' 'Data.AffineSpace.AffineSpace' instance.
 {-# INLINE addDays #-}
 addDays :: Days -> Day -> Day
 addDays = flip (.+^)
 
+-- | Subtract two calendar 'Day's for the difference in 'Days'.
+--
+-- See also 'Day' 'Data.AffineSpace.AffineSpace' instance.
 {-# INLINE diffDays #-}
 diffDays :: Day -> Day -> Days
 diffDays = (.-.)
 
+-- | Get the Gregorian calendar date from a 'Day'.
+--
+-- See also 'gregorian'.
 {-# INLINE toGregorian #-}
 toGregorian :: Day -> (Year, Month, DayOfMonth)
 toGregorian (view gregorian -> YearMonthDay y m d) = (y, m, d)
 
+-- | Construct a 'Day' from a Gregorian calendar date. Does not validate the
+-- date.
+--
+-- See also 'gregorian'.
 {-# INLINE fromGregorian #-}
 fromGregorian :: Year -> Month -> DayOfMonth -> Day
 fromGregorian y m d = gregorian # YearMonthDay y m d
 
+-- | Construct a 'Day' from a Gregorian calendar date. Returns Nothing if the
+-- date is invalid.
+--
+-- See also 'gregorian'.
 {-# INLINE fromGregorianValid #-}
 fromGregorianValid :: Year -> Month -> DayOfMonth -> Maybe Day
 fromGregorianValid y m d = gregorianValid (YearMonthDay y m d)
 
+-- | Add months, with days past the last day of the month clipped to the last
+-- day, according to the
+-- <https://en.wikipedia.org/wiki/Proleptic_Gregorian_calendar proleptic Gregorian calendar>.
+--
+-- See also 'gregorianMonthsClip'.
 {-# INLINE addGregorianMonthsClip #-}
 addGregorianMonthsClip :: Months -> Day -> Day
 addGregorianMonthsClip n = review gregorian
     . gregorianMonthsClip n . view gregorian
 
+-- | Add months, with days past the last day of the month rolling over to the
+-- next month, according to the
+-- <https://en.wikipedia.org/wiki/Proleptic_Gregorian_calendar proleptic Gregorian calendar>.
+--
+-- See also 'gregorianMonthsRollover'.
 {-# INLINE addGregorianMonthsRollover #-}
 addGregorianMonthsRollover :: Months -> Day -> Day
 addGregorianMonthsRollover n = review gregorian
     . gregorianMonthsRollover n . view gregorian
 
+-- | Add years, matching month and day, with /Feb 29th/ clipped to /Feb 28th/ if
+-- necessary.
+--
+-- See also 'gregorianYearsClip'.
 {-# INLINE addGregorianYearsClip #-}
 addGregorianYearsClip :: Years -> Day -> Day
 addGregorianYearsClip n = review gregorian
     . gregorianYearsClip n . view gregorian
 
+-- | Add years, matching month and day, with /Feb 29th/ rolled over to /Mar 1st/ if
+-- necessary, according to the
+-- <https://en.wikipedia.org/wiki/Proleptic_Gregorian_calendar proleptic Gregorian calendar>.
+--
+-- See also 'gregorianYearsRollover'.
 {-# INLINE addGregorianYearsRollover #-}
 addGregorianYearsRollover :: Years -> Day -> Day
 addGregorianYearsRollover n = review gregorian
@@ -172,53 +242,120 @@ addGregorianYearsRollover n = review gregorian
 ------------------------------------------------------------------------
 -- * @Data.Time.Calendar.MonthDay@
 
+-- | Predicated on whether or not the year is a leap year, convert an ordinal
+-- 'DayOfYear' to a ('Month','DayOfMonth')
+--
+-- See also 'Data.Thyme.Calendar.MonthDay.monthDay'.
 {-# INLINE dayOfYearToMonthAndDay #-}
-dayOfYearToMonthAndDay :: Bool -> DayOfYear -> (Month, DayOfMonth)
+dayOfYearToMonthAndDay
+    :: Bool
+        -- ^ 'Data.Thyme.Calendar.isLeapYear'?
+    -> DayOfYear
+    -> (Month, DayOfMonth)
 dayOfYearToMonthAndDay leap (view (monthDay leap) -> MonthDay m d) = (m, d)
 
+-- | Predicated on whether or not the year is a leap year, convert
+-- a 'Month' and 'DayOfMonth' to an ordinal 'DayOfYear'.
+--
+-- See also 'Data.Thyme.Calendar.MonthDay.monthDay',
+-- 'Data.Thyme.Calendar.MonthDay.monthDayValid',
+-- 'monthAndDayToDayOfYearValid'.
 {-# INLINE monthAndDayToDayOfYear #-}
-monthAndDayToDayOfYear :: Bool -> Month -> DayOfMonth -> DayOfYear
+monthAndDayToDayOfYear
+    :: Bool
+        -- ^ 'Data.Thyme.Calendar.isLeapYear'?
+    -> Month
+    -> DayOfMonth
+    -> DayOfYear
 monthAndDayToDayOfYear leap m d = monthDay leap # MonthDay m d
 
+-- | Predicated on whether or not the year is a leap year, convert
+-- a 'Month' and 'DayOfMonth' to an ordinal 'DayOfYear', or 'Nothing' on
+-- invalid input.
+--
+-- See also 'Data.Thyme.Calendar.MonthDay.monthDay',
+-- 'Data.Thyme.Calendar.MonthDay.monthDayValid',
+-- 'monthAndDayToDayOfYear'.
 {-# INLINE monthAndDayToDayOfYearValid #-}
-monthAndDayToDayOfYearValid :: Bool -> Month -> DayOfMonth -> Maybe DayOfYear
+monthAndDayToDayOfYearValid
+    :: Bool
+        -- ^ 'Data.Thyme.Calendar.isLeapYear'?
+    -> Month
+    -> DayOfMonth
+    -> Maybe DayOfYear
 monthAndDayToDayOfYearValid leap m d = monthDayValid leap (MonthDay m d)
 
 ------------------------------------------------------------------------
 -- * @Data.Time.Calendar.OrdinalDate@
 
 {-# INLINE toOrdinalDate #-}
+-- | Convert a calendar 'Day' to ('Year', 'DayOfYear')
+--
+-- See also 'ordinalDate'.
 toOrdinalDate :: Day -> (Year, DayOfYear)
 toOrdinalDate (view ordinalDate -> OrdinalDate y d) = (y, d)
 
+-- | Convert a 'Year' and 'DayOfYear' to a calendar 'Day'.
+--
+-- See also 'ordinalDate', 'ordinalDateValid', 'fromOrdinalDateValid'.
 {-# INLINE fromOrdinalDate #-}
 fromOrdinalDate :: Year -> DayOfYear -> Day
 fromOrdinalDate y d = ordinalDate # OrdinalDate y d
 
+-- | Convert a 'Year' and 'DayOfYear' to a calendar 'Day', or 'Nothing'
+-- on invalid input.
+--
+-- See also 'ordinalDate', 'ordinalDateValid', 'fromOrdinalDate'.
 {-# INLINE fromOrdinalDateValid #-}
 fromOrdinalDateValid :: Year -> DayOfYear -> Maybe Day
 fromOrdinalDateValid y d = ordinalDateValid (OrdinalDate y d)
 
+-- | Get the number of the /Sunday/-starting week in the year and the day of
+-- the week. The first /Sunday/ is the first day of week /1/, any earlier days
+-- in the year are week /0/ (as @\"%U\"@ in 'Data.Thyme.Format.formatTime').
+-- /Sunday/ is /0/, /Saturday/ is /6/
+-- (as @\"%w\"@ in 'Data.Thyme.Format.formatTime').
+--
+-- See also 'sundayWeek', 'sundayWeekValid'.
 {-# INLINE sundayStartWeek #-}
 sundayStartWeek :: Day -> (Year, WeekOfYear, DayOfWeek)
 sundayStartWeek (view sundayWeek -> SundayWeek y w d) = (y, w, d)
 
+-- | The inverse of 'sundayStartWeek'.
+--
+-- See also 'sundayWeek', 'sundayWeekValid'.
 {-# INLINE fromSundayStartWeek #-}
 fromSundayStartWeek :: Year -> WeekOfYear -> DayOfWeek -> Day
 fromSundayStartWeek y w d = sundayWeek # SundayWeek y w d
 
+-- | The inverse of 'sundayStartWeek', returns 'Nothing' for invalid input.
+--
+-- See also 'sundayWeek', 'sundayWeekValid'.
 {-# INLINE fromSundayStartWeekValid #-}
 fromSundayStartWeekValid :: Year -> WeekOfYear -> DayOfWeek -> Maybe Day
 fromSundayStartWeekValid y w d = sundayWeekValid (SundayWeek y w d)
 
+-- | Get the number of the Monday-starting week in the year and the day of
+-- the week. The first /Monday/ is the first day of week /1/, any earlier days
+-- in the year are week /0/ (as @\"%W\"@ in 'Data.Thyme.Format.formatTime').
+-- /Monday/ is /1/, /Sunday/ is /7/
+-- (as @\"%u\"@ in 'Data.Thyme.Format.formatTime').
+--
+-- See also 'mondayWeek', 'mondayWeekValid'.
 {-# INLINE mondayStartWeek #-}
 mondayStartWeek :: Day -> (Year, WeekOfYear, DayOfWeek)
 mondayStartWeek (view mondayWeek -> MondayWeek y w d) = (y, w, d)
 
+-- | The inverse of 'mondayStartWeek'.
+--
+-- See also 'mondayWeek', 'mondayWeekValid'.
 {-# INLINE fromMondayStartWeek #-}
 fromMondayStartWeek :: Year -> WeekOfYear -> DayOfWeek -> Day
 fromMondayStartWeek y w d = mondayWeek # MondayWeek y w d
 
+-- | The inverse of 'mondayStartWeek', returns 'Nothing' for invalid input.
+--
+-- See also 'mondayWeek', 'mondayWeekValid'.
 {-# INLINE fromMondayStartWeekValid #-}
 fromMondayStartWeekValid :: Year -> WeekOfYear -> DayOfWeek -> Maybe Day
 fromMondayStartWeekValid y w d = mondayWeekValid (MondayWeek y w d)
@@ -226,14 +363,24 @@ fromMondayStartWeekValid y w d = mondayWeekValid (MondayWeek y w d)
 ------------------------------------------------------------------------
 -- * @Data.Time.Calendar.WeekDate@
 
+-- | Convert a 'Day' to ('Year', 'WeekOfYear', 'DayOfWeek') according to the
+-- Iso 'weekDate'.
 {-# INLINE toWeekDate #-}
 toWeekDate :: Day -> (Year, WeekOfYear, DayOfWeek)
 toWeekDate (view weekDate -> WeekDate y w d) = (y, w, d)
 
+-- | Convert a 'Year' 'WeekOfYear' 'DayOfWeek' to a 'Day' according to the
+-- Iso 'weekDate'.
+--
+-- See also 'fromWeekDateValid'.
 {-# INLINE fromWeekDate #-}
 fromWeekDate :: Year -> WeekOfYear -> DayOfWeek -> Day
 fromWeekDate y w d = weekDate # WeekDate y w d
 
+-- | Convert a 'Year' 'WeekOfYear' 'DayOfWeek' to a 'Day' according to the
+-- Iso 'weekDateValid'.
+--
+-- See also 'fromWeekDate'.
 {-# INLINE fromWeekDateValid #-}
 fromWeekDateValid :: Year -> WeekOfYear -> DayOfWeek -> Maybe Day
 fromWeekDateValid y w d = weekDateValid (WeekDate y w d)
@@ -241,44 +388,76 @@ fromWeekDateValid y w d = weekDateValid (WeekDate y w d)
 ------------------------------------------------------------------------
 -- * @Data.Time.Clock@
 
+-- |
+-- @
+-- 'getModJulianDate' ≡ 'view' 'modJulianDate'
+-- @
 {-# INLINE getModJulianDate #-}
 getModJulianDate :: UniversalTime -> Rational
 getModJulianDate = view modJulianDate
 
 -- | Replacement for 'T.ModJulianDate'.
+-- @
+-- 'mkModJulianDate' ≡ 'review' 'modJulianDate'
+-- @
 {-# INLINE mkModJulianDate #-}
 mkModJulianDate :: Rational -> UniversalTime
 mkModJulianDate = review modJulianDate
 
+-- | Construct a 'DiffTime' from seconds.
+--
+-- See also 'fromSeconds'.
 {-# INLINE secondsToDiffTime #-}
 secondsToDiffTime :: Int64 -> DiffTime
 secondsToDiffTime a = DiffTime (Micro $ a * 1000000)
 
+-- | Construct a 'DiffTime' from picoseconds, but only to microsecond precision.
+-- (The bottom six orders of magnitude are discarded.)
+--
+-- See also 'microseconds'.
 {-# INLINE picosecondsToDiffTime #-}
 picosecondsToDiffTime :: Int64 -> DiffTime
 picosecondsToDiffTime a = DiffTime . Micro $
     quot (a + signum a * 500000) 1000000
 
+-- | Constructor for 'UTCTime'.
+--
+-- See also 'utcTime'.
 {-# INLINE mkUTCTime #-}
 mkUTCTime :: Day -> DiffTime -> UTCTime
 mkUTCTime d t = utcTime # UTCView d t
 
+-- | Decompose a 'UTCTime' into a 'UTCView'.
+--
+-- See also 'utcTime'.
 {-# INLINE unUTCTime #-}
 unUTCTime :: UTCTime -> UTCView
 unUTCTime = view utcTime
 
+-- | Add a duration to a time point.
+--
+-- See also "Data.AffineSpace" instance of 'UTCTime'.
 {-# INLINE addUTCTime #-}
 addUTCTime :: NominalDiffTime -> UTCTime -> UTCTime
 addUTCTime = flip (.+^)
 
+-- | The duration difference between two time points.
+--
+-- See also "Data.AffineSpace" instance of 'UTCTime'.
 {-# INLINE diffUTCTime #-}
 diffUTCTime :: UTCTime -> UTCTime -> NominalDiffTime
 diffUTCTime = (.-.)
 
+-- | Convert a 'DiffTime' or 'NominalDiffTime' to microseconds.
+--
+-- See also 'microseconds'.
 {-# INLINE toMicroseconds #-}
 toMicroseconds :: (TimeDiff t) => t -> Int64
 toMicroseconds = view microseconds
 
+-- | Convert microseconds to a 'DiffTime' or 'NominalDiffTime'.
+--
+-- See also 'microseconds'.
 {-# INLINE fromMicroseconds #-}
 fromMicroseconds :: (TimeDiff t) => Int64 -> t
 fromMicroseconds = review microseconds
@@ -286,10 +465,18 @@ fromMicroseconds = review microseconds
 ------------------------------------------------------------------------
 -- * @Data.Time.Clock.POSIX@
 
+-- |
+-- @
+-- 'posixSecondsToUTCTime' ≡ 'review' 'posixTime'
+-- @
 {-# INLINE posixSecondsToUTCTime #-}
 posixSecondsToUTCTime :: POSIXTime -> UTCTime
 posixSecondsToUTCTime = review posixTime
 
+-- |
+-- @
+-- 'utcTimeToPOSIXSeconds' ≡ 'view' 'posixTime'
+-- @
 {-# INLINE utcTimeToPOSIXSeconds #-}
 utcTimeToPOSIXSeconds :: UTCTime -> POSIXTime
 utcTimeToPOSIXSeconds = view posixTime
@@ -297,18 +484,32 @@ utcTimeToPOSIXSeconds = view posixTime
 ------------------------------------------------------------------------
 -- * @Data.Time.Clock.TAI@
 
+-- | Add a duration to an 'AbsoluteTime'.
+--
+-- See also the 'Data.AffineSpace.+^' operator for
+-- the 'Data.AffineSpace.AffineSpace' instance of 'AbsoluteTime'.
 {-# INLINE addAbsoluteTime #-}
 addAbsoluteTime :: DiffTime -> AbsoluteTime -> AbsoluteTime
 addAbsoluteTime = flip (.+^)
 
+-- | The duration difference between two 'AbsoluteTime's.
+--
+-- See also the 'Data.AffineSpace..-.' operator for
+-- the 'Data.AffineSpace.AffineSpace' instance of 'AbsoluteTime'.
 {-# INLINE diffAbsoluteTime #-}
 diffAbsoluteTime :: AbsoluteTime -> AbsoluteTime -> DiffTime
 diffAbsoluteTime = (.-.)
 
+-- | Using a 'LeapSecondTable', convert a 'UTCTime' to 'AbsoluteTime'.
+--
+-- See also the Iso 'absoluteTime'.
 {-# INLINE utcToTAITime #-}
 utcToTAITime :: LeapSecondTable -> UTCTime -> AbsoluteTime
 utcToTAITime = view . absoluteTime
 
+-- | Using a 'LeapSecondTable', convert a 'AbsoluteTime' to 'UTCTime'.
+--
+-- See also the Iso 'absoluteTime'.
 {-# INLINE taiToUTCTime #-}
 taiToUTCTime :: LeapSecondTable -> AbsoluteTime -> UTCTime
 taiToUTCTime = review . absoluteTime
@@ -316,50 +517,101 @@ taiToUTCTime = review . absoluteTime
 ------------------------------------------------------------------------
 -- * @Data.Time.LocalTime@
 
+-- | Convert a UTC time-of-day to a local time-of-day.
+--
+-- @
+-- 'utcToLocalTimeOfDay' ≡ 'Data.Thyme.LocalTime.addMinutes' . 'Data.Thyme.LocalTime.timeZoneMinutes'
+-- @
+--
+-- See also Iso 'Data.Thyme.LocalTime.utcLocalTime'
 {-# INLINE utcToLocalTimeOfDay #-}
 utcToLocalTimeOfDay :: TimeZone -> TimeOfDay -> (Days, TimeOfDay)
 utcToLocalTimeOfDay = addMinutes . timeZoneMinutes
 
+-- | Convert a local time to a UTC time.
+--
+-- @
+-- 'localToUTCTimeOfDay' ≡ 'Data.Thyme.LocalTime.addMinutes' . 'negate' . 'Data.Thyme.LocalTime.timeZoneMinutes'
+-- @
+--
+-- See also Iso 'Data.Thyme.LocalTime.utcLocalTime'
 {-# INLINE localToUTCTimeOfDay #-}
 localToUTCTimeOfDay :: TimeZone -> TimeOfDay -> (Days, TimeOfDay)
 localToUTCTimeOfDay = addMinutes . negate . timeZoneMinutes
 
+-- |
+-- @
+-- 'timeToTimeOfDay' ≡ 'view' 'Data.Thyme.LocalTime.timeOfDay'
+-- @
 {-# INLINE timeToTimeOfDay #-}
 timeToTimeOfDay :: DiffTime -> TimeOfDay
 timeToTimeOfDay = view timeOfDay
 
+-- | Convert 'TimeOfDay' to 'DiffTime'.
+--
+-- See also 'Data.Thyme.LocalTime.timeOfDay'.
 {-# INLINE timeOfDayToTime #-}
 timeOfDayToTime :: TimeOfDay -> DiffTime
 timeOfDayToTime = review timeOfDay
 
+-- |
+-- @
+-- 'dayFractionToTimeOfDay' ≡ 'review' 'Data.Thyme.LocalTime.dayFraction'
+-- @
 {-# INLINE dayFractionToTimeOfDay #-}
 dayFractionToTimeOfDay :: Rational -> TimeOfDay
 dayFractionToTimeOfDay = review dayFraction
 
+-- |
+-- @
+-- 'timeOfDayToDayFraction' ≡ 'view' 'Data.Thyme.LocalTime.dayFraction'
+-- @
 {-# INLINE timeOfDayToDayFraction #-}
 timeOfDayToDayFraction :: TimeOfDay -> Rational
 timeOfDayToDayFraction = view dayFraction
 
+-- |
+-- @
+-- 'utcToLocalTime' ≡ 'view' . 'Data.Thyme.LocalTime.utcLocalTime'
+-- @
 {-# INLINE utcToLocalTime #-}
 utcToLocalTime :: TimeZone -> UTCTime -> LocalTime
 utcToLocalTime = view . utcLocalTime
 
+-- |
+-- @
+-- 'localTimeToUTC' ≡ 'review' . 'Data.Thyme.LocalTime.utcLocalTime'
+-- @
 {-# INLINE localTimeToUTC #-}
 localTimeToUTC :: TimeZone -> LocalTime -> UTCTime
 localTimeToUTC = review . utcLocalTime
 
+-- |
+-- @
+-- 'ut1ToLocalTime' ≡ 'view' . 'Data.Thyme.LocalTime.ut1LocalTime'
+-- @
 {-# INLINE ut1ToLocalTime #-}
 ut1ToLocalTime :: Rational -> UniversalTime -> LocalTime
 ut1ToLocalTime = view . ut1LocalTime
 
+-- |
+-- @
+-- 'localTimeToUT1' ≡ 'review' . 'Data.Thyme.LocalTime.ut1LocalTime'
+-- @
 {-# INLINE localTimeToUT1 #-}
 localTimeToUT1 :: Rational -> LocalTime -> UniversalTime
 localTimeToUT1 = review . ut1LocalTime
 
+-- | Combine a 'TimeZone' and a 'UTCTime' into a 'ZonedTime'.
+--
+-- See also Iso 'Data.Thyme.LocalTime.zonedTime'
 {-# INLINE utcToZonedTime #-}
 utcToZonedTime :: TimeZone -> UTCTime -> ZonedTime
 utcToZonedTime z t = view zonedTime (z, t)
 
+-- | Convert a 'ZonedTime' to a 'UTCTime'.
+--
+-- See also Iso 'Data.Thyme.LocalTime.zonedTime'
 {-# INLINE zonedTimeToUTC #-}
 zonedTimeToUTC :: ZonedTime -> UTCTime
 zonedTimeToUTC = snd . review zonedTime

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,6 @@
+flags: {}
+extra-package-dbs: []
+packages:
+- '.'
+extra-deps: []
+resolver: lts-5.11


### PR DESCRIPTION
In addition to documentation, made these changes:

* Created stack.yaml
* Created Data.Thyme.Clock.hhmmss
* Created Data.Thyme.Format.timeZoneOffsetStringColon, added "%N" format spec for ISO 8601.
* Added "%v" Data.Thyme.Format spec for microseconds.
* Exported constructor for AbsoluteTime.
* Applied patch https://github.com/liyang/thyme/issues/38
    - Unconditionally import Control.Applicative in module Data.Thyme.Clock.TAI
* Created unexported Data.Thyme.Clock.TAI._parseTAIUTCDAT' [WIP]
    - Reports parsing errors.
    - Enables examination of the leap second table.