### PR TITLE
Implement time parsing benchmarks

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -3,4 +3,4 @@ extra-package-dbs: []
 packages:
 - '.'
 extra-deps: []
-resolver: lts-5.11
+resolver: lts-11.13

--- a/tests/bench.hs
+++ b/tests/bench.hs
@@ -1,2 +1,34 @@
+{-# LANGUAGE TypeApplications #-}
+
+module Main where
+
+import Criterion.Main
+import Control.DeepSeq (($!!))
+import qualified Data.ByteString.Char8 as BS8
+import Test.QuickCheck (arbitrary)
+import Data.Attoparsec.ByteString (parseOnly)
+
+import qualified Data.Time as Time
+import qualified Data.Thyme as Thyme
+
 main :: IO ()
-main = return ()
+main = do
+    utcthyme <- generate arbitrary :: IO Thyme.UTCTime
+    let isoFormatString = "%Y-%m-%dT%H:%M:%S%N"
+        renderIsoTime = Thyme.formatTime Thyme.defaultTimeLocale "%Y-%m-%dT%H:%M:%S%N"
+    string <- return $!! renderIsoTime utcthyme
+    bytestring <- return $!! BS8.pack (renderIsoTime utcthyme)
+
+    defaultMain
+        [ bgroup "parsing"
+            [ bench "Thyme.parseTime" $ nf
+                ((Thyme.parseTime Thyme.defaultTimeLocale isoFormatString :: String -> Maybe Thyme.UTCTime))
+                string
+            , bench "Time.parseTimeM" $ nf
+                (Time.parseTimeM True Time.defaultTimeLocale isoFormatString :: String -> Maybe Time.UTCTime)
+                string
+            , bench "Thyme.timeParser" $ nf
+                (fmap (Thyme.buildTime @Thyme.UTCTime) . parseOnly (Thyme.timeParser Thyme.defaultTimeLocale isoFormatString))
+                bytestring
+            ]
+        ]

--- a/tests/bench.hs
+++ b/tests/bench.hs
@@ -3,9 +3,10 @@
 module Main where
 
 import Criterion.Main
+import Data.Maybe (fromMaybe)
 import Control.DeepSeq (($!!))
 import qualified Data.ByteString.Char8 as BS8
-import Test.QuickCheck (arbitrary)
+import Test.QuickCheck (arbitrary, generate)
 import Data.Attoparsec.ByteString (parseOnly)
 
 import qualified Data.Time as Time
@@ -14,21 +15,29 @@ import qualified Data.Thyme as Thyme
 main :: IO ()
 main = do
     utcthyme <- generate arbitrary :: IO Thyme.UTCTime
-    let isoFormatString = "%Y-%m-%dT%H:%M:%S%N"
-        renderIsoTime = Thyme.formatTime Thyme.defaultTimeLocale "%Y-%m-%dT%H:%M:%S%N"
+    let isoFormatString = "%Y-%m-%dT%H:%M:%S"
+        renderIsoTime = Thyme.formatTime Thyme.defaultTimeLocale isoFormatString
+        thymeParser :: String -> Thyme.UTCTime
+        thymeParser =
+            fromMaybe (error "Failed in thymeParser")
+            . Thyme.parseTime Thyme.defaultTimeLocale isoFormatString
+        timeParser :: String -> Time.UTCTime
+        timeParser =
+            fromMaybe (error "Failed in timeParser")
+            . Time.parseTimeM True Time.defaultTimeLocale isoFormatString
+        thymeAttoparsec :: BS8.ByteString -> Thyme.UTCTime
+        thymeAttoparsec =
+            Thyme.buildTime @Thyme.UTCTime
+            . either error id
+            . parseOnly (Thyme.timeParser Thyme.defaultTimeLocale isoFormatString)
+
     string <- return $!! renderIsoTime utcthyme
     bytestring <- return $!! BS8.pack (renderIsoTime utcthyme)
 
     defaultMain
         [ bgroup "parsing"
-            [ bench "Thyme.parseTime" $ nf
-                ((Thyme.parseTime Thyme.defaultTimeLocale isoFormatString :: String -> Maybe Thyme.UTCTime))
-                string
-            , bench "Time.parseTimeM" $ nf
-                (Time.parseTimeM True Time.defaultTimeLocale isoFormatString :: String -> Maybe Time.UTCTime)
-                string
-            , bench "Thyme.timeParser" $ nf
-                (fmap (Thyme.buildTime @Thyme.UTCTime) . parseOnly (Thyme.timeParser Thyme.defaultTimeLocale isoFormatString))
-                bytestring
+            [ bench "Time.parseTimeM" $ nf timeParser  string
+            , bench "Thyme.parseTime" $ nf thymeParser string
+            , bench "Thyme.timeParser" $ nf thymeAttoparsec bytestring
             ]
         ]

--- a/thyme.cabal
+++ b/thyme.cabal
@@ -178,14 +178,18 @@ benchmark bench
     if !flag(lens)
         other-modules: Control.Lens
     build-depends:
+        attoparsec,
         QuickCheck,
         base,
+        bytestring,
         criterion,
+        deepseq,
         mtl,
         old-locale,
         random,
         thyme,
         time,
+        QuickCheck,
         vector,
         vector-space
     if flag(lens)


### PR DESCRIPTION
This PR implements some benchmarks comparing various time parsing functionality. The difference is pretty significant:

```
benchmarking parsing/Thyme.parseTime
time                 2.042 μs   (2.004 μs .. 2.080 μs)
                     0.998 R²   (0.996 R² .. 1.000 R²)
mean                 1.989 μs   (1.973 μs .. 2.018 μs)
std dev              73.99 ns   (49.60 ns .. 122.6 ns)
variance introduced by outliers: 50% (severely inflated)

benchmarking parsing/Time.parseTimeM
time                 3.253 μs   (3.240 μs .. 3.269 μs)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 3.253 μs   (3.229 μs .. 3.304 μs)
std dev              112.9 ns   (60.74 ns .. 221.4 ns)
variance introduced by outliers: 46% (moderately inflated)

benchmarking parsing/Thyme.timeParser
time                 1.334 μs   (1.328 μs .. 1.342 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 1.333 μs   (1.327 μs .. 1.341 μs)
std dev              23.75 ns   (17.22 ns .. 34.88 ns)
variance introduced by outliers: 19% (moderately inflated)
```